### PR TITLE
Fix warning for legacy ENV format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM ubuntu:noble
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-ENV GUITARIX_VERSION V0.46.0
+ENV GUITARIX_VERSION=V0.46.0
 
 RUN apt-get update -y && apt-get install -y \
         apt-utils \


### PR DESCRIPTION
This fixes the warning we get when building the container with docker v28.1.1:
> 1 warning found (use docker --debug to expand):
> - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 8)